### PR TITLE
use pnpm publish directly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install
@@ -38,7 +38,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm run release
+          publish: pnpm -r publish
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "release": "pnpm -r publish",
     "version": "changeset version"
   },
   "keywords": [],


### PR DESCRIPTION
using `pnpm run` means we don't have access to `NPM_TOKEN` anymore. I think… 